### PR TITLE
feat: scheduler wrappers for JS interop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.graalvm.sdk</groupId>
+      <artifactId>graal-sdk</artifactId>
+      <version>20.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.destroystokyo.paper</groupId>
       <artifactId>paper-api</artifactId>
       <version>1.16.1-R0.1-SNAPSHOT</version>

--- a/src/main/java/org/potaska/JSPlugin.java
+++ b/src/main/java/org/potaska/JSPlugin.java
@@ -1,7 +1,6 @@
 package org.potaska;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
@@ -9,10 +8,8 @@ import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -22,7 +19,11 @@ import java.util.stream.Stream;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.graalvm.polyglot.*;
+import org.bukkit.scheduler.BukkitTask;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.HostAccess;
+import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.Source;
 
 public class JSPlugin extends JavaPlugin {
   Context ctx;
@@ -32,6 +33,31 @@ public class JSPlugin extends JavaPlugin {
   public void refresh() {
     Bukkit.getPluginManager().disablePlugin(this);
     Bukkit.getPluginManager().enablePlugin(this);
+  }
+  
+  /**
+   * Schedules a task once.
+   * @param task Task to run.
+   * @param delay Delay in ticks.
+   * @return Id of new task.
+   */
+  public int scheduleOnce(Runnable task, long delay) {
+	  if (delay == 0) {
+		  return Bukkit.getScheduler().scheduleSyncDelayedTask(this, task);
+	  } else {
+		  return Bukkit.getScheduler().scheduleSyncDelayedTask(this, task, delay);
+	  }
+  }
+  
+  /**
+   * Schedules a repeating task.
+   * @param task Task to run.
+   * @param delay Initial delay.
+   * @param period Time between executions.
+   * @return Id of new task.
+   */
+  public int scheduleRepeating(Runnable task, long delay, long period) {
+	  return Bukkit.getScheduler().scheduleSyncRepeatingTask(this, task, delay, period);
   }
 
   @Override
@@ -64,7 +90,6 @@ public class JSPlugin extends JavaPlugin {
         URL zipUrl = new URL(jsZip);
         ReadableByteChannel rbc = Channels.newChannel(zipUrl.openStream());
         FileOutputStream os = new FileOutputStream(zipPath.toFile());
-        FileChannel fc = os.getChannel();
         os.getChannel().transferFrom(rbc, 0, Long.MAX_VALUE);
 
         Path root = Utils.unzip(zipPath.toFile(), tmpDir.toFile()).toPath();


### PR DESCRIPTION
They can be called without reflection, which in turn allows passing JS functions as Runnables.

Also made this compile without GraalVM; running still requires it or OpenJDK with some command-line options.